### PR TITLE
chore: ignore updates for eslint-config-6river (EXP-1148)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
   reviewers:
   - AdamVig
   versioning-strategy: widen
+  ignore:
+    - dependency-name: "eslint-config-6river"


### PR DESCRIPTION
See https://github.com/6RiverSystems/eslint-config-6river/pull/118.

### Commits

- chore: ignore updates for eslint-config-6river
  This avoids an update loop that would occur between this package and
  `eslint-config-6river`.